### PR TITLE
Fix typo in provisioner.js (lenth => length)

### DIFF
--- a/bin/provisioner.js
+++ b/bin/provisioner.js
@@ -135,7 +135,7 @@ var queueDefns = [
     },
     {
         name: 'zfs_query',
-        maxConcurrent: os.cpus().lenth,
+        maxConcurrent: os.cpus().length,
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [


### PR DESCRIPTION
This has been causing there to be no limit on the number of concurrent zfs_query tasks that provisioner can spawn, occasionally leading to retry/timeout storms on busy CNs with lots of zfs datasets.