### PR TITLE
Lower limits for maximum concurrency of tasks in provisioner

### DIFF
--- a/bin/provisioner.js
+++ b/bin/provisioner.js
@@ -31,12 +31,21 @@ var options = {
     use_system_config: true
 };
 
+var cpuLimit = function(min, max) {
+    var cpus = os.cpus().length;
+    if (cpus < min)
+        return min;
+    if (cpus > max)
+        return max;
+    return cpus;
+}
+
 var agent = new TaskAgent(options);
 
 var queueDefns = [
     {
         name: 'machine_creation',
-        maxConcurrent: os.cpus().length,
+        maxConcurrent: cpuLimit(4, 8),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [ 'machine_create', 'machine_reprovision' ]
@@ -50,7 +59,7 @@ var queueDefns = [
     },
     {
         name: 'server_tasks',
-        maxConcurrent: os.cpus().length,
+        maxConcurrent: 1,
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [
@@ -68,7 +77,7 @@ var queueDefns = [
     },
     {
         name: 'machine_tasks',
-        maxConcurrent: os.cpus().length,
+        maxConcurrent: cpuLimit(4, 8),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [
@@ -88,7 +97,7 @@ var queueDefns = [
     {
         name: 'machine_images',
         expires: 60, // expire messages in this queue after a minute
-        maxConcurrent: 64,
+        maxConcurrent: cpuLimit(4, 16),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [
@@ -98,7 +107,7 @@ var queueDefns = [
     {
         name: 'image_query',
         expires: 60, // expire messages in this queue after a minute
-        maxConcurrent: 64,
+        maxConcurrent: cpuLimit(16, 64),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         logging: false,
@@ -109,7 +118,7 @@ var queueDefns = [
     {
         name: 'machine_query',
         expires: 60, // expire messages in this queue after a minute
-        maxConcurrent: 64,
+        maxConcurrent: cpuLimit(16, 32),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         logging: false,
@@ -120,7 +129,7 @@ var queueDefns = [
     },
     {
         name: 'zfs_tasks',
-        maxConcurrent: os.cpus().length,
+        maxConcurrent: cpuLimit(4, 8),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [
@@ -135,7 +144,7 @@ var queueDefns = [
     },
     {
         name: 'zfs_query',
-        maxConcurrent: os.cpus().length,
+        maxConcurrent: cpuLimit(4, 8),
         onmsg: createTaskDispatchFn(agent, tasksPath),
         onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
         tasks: [


### PR DESCRIPTION
This patch lowers the concurrency limits significantly for provisioner's operation queues. It's also about starting a discussion, about how high these limits should actually be.

Currently, the concurrency limits for the provisioner agent are really quite high for a lot of tasks -- including numbers like 64 or #cpus (which on our CNs is usually 32) -- and some of these tasks, like 'zfs list' and 'zfs snapshot' are ones that take a lot of locks around the place, so this can get tricky.

I'll give some rough data for one of our problematic CNs:

```bash
[root@a0-36-9f-10-86-20 (gps-1) ~]# function timezfs { \
>    n=$1; \
>    time ( \
>        for x in $(seq 1 $n); do \
>            zfs list -H -p -t filesystem,snapshot,volume -o compression,creation,mountpoint,name,quota,recsize,refreservation,type,userrefs,volblocksize,volsize,zoned >/dev/null &
>        done;
>        wait ) }

[root@a0-36-9f-10-86-20 (gps-1) ~]# timezfs 4
real	0m3.040s
user	0m2.462s
sys	0m8.234s

[root@a0-36-9f-10-86-20 (gps-1) ~]# timezfs 8
real	0m4.445s
user	0m5.077s
sys	0m21.548s

[root@a0-36-9f-10-86-20 (gps-1) ~]# timezfs 32
real	0m18.008s
user	0m29.227s
sys	7m25.010s

[root@a0-36-9f-10-86-20 (gps-1) ~]# timezfs 64
real	0m35.259s
user	0m58.043s
sys	15m41.837s
```

As you can see, the limit of safe concurrency for this box on zfs lists is probably about 8 if you want to make sure 8 parallel operations all started at once can finish within 5 seconds. The limits for other operations like creating snapshots that require writing to disk, should probably be even lower.

With higher limits (e.g. currently the default is #cpus, or 32 on this box), this kind of situation where the maximum number of parallel operations all start at once causes timeouts to happen in the layers above (which can happen regularly when the heartbeater makes a pile of calls at once, amongst other things).

In some cases you can even get what I like to call a "retry storm", where it seems like vmapi is retrying its call to cnapi which is retrying its call to provisioner which is spawning tonnes of parallel jobs to do exactly the same thing. And all of them take too long to finish, so they time out, and then a retry happens... you get the idea.

It's much better with a lower concurrency limit on the provisioner queues though -- less concurrency stops the operations from taking so long to complete, meaning it can gradually eat through the backlog of retrying operations.

Some other previous evidence that these limits should be lower, in my opinion includes the VM.js code where there's actually a queue to serialise lots of zfs operations, including 'zfs list' calls, which tries to limit things to 1 (!) concurrent 'zfs list' at a time. There are comments there about parallel zfs lists being very slow (this limit code would be affecting provisioner, too, except that it forks and so there's one of these queues in VM.js in every child process).